### PR TITLE
Add dynamic controller example for partial observations

### DIFF
--- a/partial_observed_policy_gradient.py
+++ b/partial_observed_policy_gradient.py
@@ -1,0 +1,98 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import scipy.linalg as la
+
+try:
+    import matplotlib.pyplot as plt
+    HAVE_PLT = True
+except ModuleNotFoundError:
+    HAVE_PLT = False
+
+"""Model-based policy gradient for a partially observed LQR system.
+
+We consider
+  x_{t+1} = A x_t + B u_t + w_t,
+  y_t     = C x_t + v_t,
+where w_t ~ N(0, I) and v_t ~ N(0, 1).
+The controller has internal state z_t and is parameterized by matrices
+(A_K, B_K, C_K):
+  z_{t+1} = A_K z_t + B_K y_t,
+  u_t     = C_K z_t.
+Gradient descent is performed on (A_K, B_K, C_K), and the resulting cost is
+compared against the optimal LQG controller obtained from Riccati equations.
+"""
+
+# System matrices
+A = jnp.array([[1., 1.], [0., 1.]])
+B = jnp.array([[0.], [1.]])
+C = jnp.array([[1., 0.]])
+
+# Cost weights
+Q_cost = jnp.eye(2)
+R_cost = jnp.array([[1.]])
+
+# Noise covariances
+Sigma_w = jnp.eye(2)
+Sigma_v = jnp.array([[1.]])
+
+# Riccati solutions for the optimal LQG controller
+P_f = jnp.array(la.solve_discrete_are(A.T, C.T, Sigma_w, Sigma_v))
+L_opt = P_f @ C.T @ jnp.linalg.inv(C @ P_f @ C.T + Sigma_v)
+P = jnp.array(la.solve_discrete_are(A, B, Q_cost, R_cost))
+K_lqr = jnp.linalg.inv(B.T @ P @ B + R_cost) @ (B.T @ P @ A)
+
+# Optimal dynamic controller matrices
+A_K_opt = A - B @ K_lqr - L_opt @ C
+B_K_opt = L_opt
+C_K_opt = -K_lqr
+
+@jax.jit
+def dlyap(A_mat, Q_mat):
+    """Solve X = A X A^T + Q for X."""
+    n = A_mat.shape[0]
+    lhs = jnp.eye(n * n) - jnp.kron(A_mat, A_mat)
+    x = jnp.linalg.solve(lhs, Q_mat.reshape(-1))
+    return x.reshape(n, n)
+
+@jax.jit
+def cost(params):
+    """Infinite-horizon cost for controller parameters."""
+    A_K, B_K, C_K = params
+    F = jnp.block([[A, B @ C_K],
+                   [B_K @ C, A_K]])
+    W = jnp.block([[Sigma_w, jnp.zeros((2, 2))],
+                   [jnp.zeros((2, 2)), B_K @ Sigma_v @ B_K.T]])
+    Sigma = dlyap(F, W)
+    Sigma_x = Sigma[:2, :2]
+    Sigma_z = Sigma[2:, 2:]
+    return jnp.trace(Q_cost @ Sigma_x) + jnp.trace(C_K @ Sigma_z @ C_K.T)
+
+grad_cost = jax.jit(jax.grad(cost))
+
+alpha = 0.05
+n_iterations = 50
+
+params = [0.8 * A_K_opt, 0.8 * B_K_opt, 0.8 * C_K_opt]
+
+cost_history = []
+for _ in range(n_iterations):
+    c = cost(params)
+    cost_history.append(float(c))
+    grads = grad_cost(params)
+    params = [p - alpha * g for p, g in zip(params, grads)]
+
+cost_history.append(float(cost(params)))
+cost_opt = float(cost([A_K_opt, B_K_opt, C_K_opt]))
+
+if HAVE_PLT:
+    plt.plot(cost_history, label="learned controller")
+    plt.plot([cost_opt] * len(cost_history), "--", label="optimal controller")
+    plt.xlabel("Iteration")
+    plt.ylabel("Cost")
+    plt.legend()
+    plt.tight_layout()
+    plt.show()
+else:
+    print("matplotlib not available, skipping plot")
+    print("Final cost:", cost_history[-1])


### PR DESCRIPTION
## Summary
- implement policy gradient on dynamic controller matrices `A_K`, `B_K`, `C_K`
- compute infinite-horizon cost via Lyapunov solution
- start near the LQG controller obtained from Riccati equations
- gracefully handle missing matplotlib when plotting

## Testing
- `python partial_observed_policy_gradient.py`

------
https://chatgpt.com/codex/tasks/task_e_683f78c1e89c8327a2fab6c719e2266d