### PR TITLE
Fix variable ordering in prediction error function

### DIFF
--- a/system_identification.py
+++ b/system_identification.py
@@ -170,7 +170,7 @@ def identify_system(us, ys, n_iter=10, rng=None, order=2):
 
 def one_step_prediction_error(A_est, B_est, C_est, rng):
     """Return root mean squared prediction error for the given data."""
-    ys, us = collect_data(50000, rng, closed_loop=True)
+    us, ys = collect_data(50000, rng, closed_loop=True)
     n = A_est.shape[0]
     T = us.shape[1]
     x_pred = np.zeros((n, 1))


### PR DESCRIPTION
## Summary
- fix order of `collect_data` return values in `one_step_prediction_error`
- confirmed function runs without errors

## Testing
- `python - <<'PY'
import numpy as np
from system_identification import one_step_prediction_error, A_true, B_true, C_true
err = one_step_prediction_error(A_true, B_true, C_true, np.random.default_rng())
print('err', err)
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6840fc3eece08327b041ba27163ffc07