### PR TITLE
Fix n4sid input slice

### DIFF
--- a/system_identification.py
+++ b/system_identification.py
@@ -153,7 +153,7 @@ def n4sid(us, ys, order=2, blocks=10):
 
     X_prev = X[:, :-1]
     X_next = X[:, 1:]
-    U_reg = us[:, 2 * blocks - 1:T - 1]
+    U_reg = us[:, blocks:T - blocks]
     Phi = np.vstack([X_prev, U_reg])
     target = X_next
     Theta = target @ np.linalg.pinv(Phi)


### PR DESCRIPTION
## Summary
- align input regression slice in `n4sid()` with the corresponding state estimates

## Testing
- `python - <<'PY'
import numpy as np
from system_identification import collect_data, n4sid
us, ys = collect_data(100, rng=np.random.default_rng(), closed_loop=True)
A_est, B_est, C_est = n4sid(us, ys, order=2, blocks=10)
print('A_est shape', A_est.shape)
print('B_est shape', B_est.shape)
print('C_est shape', C_est.shape)
PY
`
- `python - <<'PY'
import numpy as np
from system_identification import collect_data, n4sid, lqg_controller
us, ys = collect_data(100, rng=np.random.default_rng(), closed_loop=True)
A_est, B_est, C_est = n4sid(us, ys, order=2, blocks=10)
K, L = lqg_controller(A_est, B_est, C_est)
print('spectral radius', np.max(np.abs(np.linalg.eigvals(A_est + B_est @ K))))
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6841ffa784fc83278b6facdb83375314